### PR TITLE
Fix errors caused by more recent versions of numpy and torch

### DIFF
--- a/data_manager.py
+++ b/data_manager.py
@@ -93,7 +93,7 @@ class DataManager(object):
                     lens.append(len(ids))
 
         lens = np.array(lens)
-        data = np.array(data)
+        data = np.array(data, dtype=object)
         sorted_idxs = np.argsort(lens)
         lens = lens[sorted_idxs]
         data = data[sorted_idxs]

--- a/layers.py
+++ b/layers.py
@@ -337,7 +337,7 @@ class Decoder(nn.Module):
         not_eos_mask = (torch.arange(num_classes).reshape(1, -1) != eos_id).type(encoder_mask.type())
         maximum_length = max_len.max().item()
         ret = [None] * batch_size
-        batch_idxs = torch.arange(batch_size)
+        batch_idxs = torch.arange(batch_size, device=all_symbols.device)
         for time_step in range(1, maximum_length + 1):
             surpass_length = (max_len < time_step) + (time_step == maximum_length)
             finished_decoded = torch.sum((all_symbols[:, :, -1] == eos_id).type(max_len.type()), -1) == beam_size


### PR DESCRIPTION
- more recent versions of numpy require np.array(..., dtype=object) for ragged arrays
- put batch_idxs on same device as finished_sents